### PR TITLE
ggml: add Vulkan and SYCL backends for TQ3_0 KV cache quantization

### DIFF
--- a/ggml/src/ggml-common.h
+++ b/ggml/src/ggml-common.h
@@ -274,6 +274,7 @@ static_assert(sizeof(block_tq2_0) == sizeof(ggml_half) + QK_K / 4, "wrong tq2_0 
 //   - FP16 residual norm ||r||₂ for QJL scaling
 // Requires per-model rotation matrices Π and S (stored externally)
 #define QK_TQ3_0 32
+#define QR_TQ3_0 1  // iqs stride: 1 element per logical unit (full block decoded per call)
 typedef struct {
     uint8_t   qs[QK_TQ3_0 / 4]; // 2-bit codebook indices, 32 × 2 bits = 8 bytes
     uint8_t   qr[QK_TQ3_0 / 8]; // QJL residual signs, 32 × 1 bit = 4 bytes

--- a/ggml/src/ggml-sycl/convert.cpp
+++ b/ggml/src/ggml-sycl/convert.cpp
@@ -603,6 +603,8 @@ to_fp16_sycl_t ggml_get_to_fp16_sycl(ggml_type type, ggml_tensor * dst) {
             return dequantize_block_sycl<QK5_1, QR5_1, dequantize_q5_1>;
         case GGML_TYPE_Q8_0:
             return dequantize_block_sycl<QK8_0, QR8_0, dequantize_q8_0>;
+        case GGML_TYPE_TQ3_0:
+            return dequantize_block_sycl<QK_TQ3_0, QR_TQ3_0, dequantize_tq3_0>;
         case GGML_TYPE_Q2_K:
             return dequantize_row_q2_K_sycl;
         case GGML_TYPE_Q3_K:
@@ -669,6 +671,8 @@ to_fp32_sycl_t ggml_get_to_fp32_sycl(ggml_type type, ggml_tensor *dst) {
             return dequantize_block_sycl<QK5_1, QR5_1, dequantize_q5_1>;
         case GGML_TYPE_Q8_0:
             return dequantize_block_sycl<QK8_0, QR8_0, dequantize_q8_0>;
+        case GGML_TYPE_TQ3_0:
+            return dequantize_block_sycl<QK_TQ3_0, QR_TQ3_0, dequantize_tq3_0>;
         case GGML_TYPE_Q2_K:
             return dequantize_row_q2_K_sycl;
         case GGML_TYPE_Q3_K:
@@ -738,6 +742,8 @@ to_fp16_nc_sycl_t ggml_get_to_fp16_nc_sycl(ggml_type type) {
             return dequantize_block_nc_sycl<QK5_1, QR5_1, dequantize_q5_1>;
         case GGML_TYPE_Q8_0:
             return dequantize_block_nc_sycl<QK8_0, QR8_0, dequantize_q8_0>;
+        case GGML_TYPE_TQ3_0:
+            return dequantize_block_nc_sycl<QK_TQ3_0, QR_TQ3_0, dequantize_tq3_0>;
         default:
             return nullptr;
     }

--- a/ggml/src/ggml-sycl/dequantize.hpp
+++ b/ggml/src/ggml-sycl/dequantize.hpp
@@ -838,4 +838,118 @@ static void dequantize_block_mxfp4(const void * __restrict__ vx, dst_t * __restr
     }
 }
 
+
+
+// ============================================================
+// TurboQuant TQ3_0 dequantization for Intel SYCL backend
+// Port of the CPU reference in ggml-quants.c to SYCL
+//
+// TQ3_0 layout per 32-value block (14 bytes total):
+//   qs[8]  : 2-bit codebook indices (4 per byte)
+//   qr[4]  : QJL residual sign bits (8 per byte) — stored but unused in dequant
+//   gamma  : FP16 per-block scale
+//
+// Dequant: scale * centroid[2bit_idx] → inverse WHT-32
+// WHT is self-inverse: apply once forward, once inverse = identity × 32
+// ============================================================
+
+// Fixed random sign pattern (seed 42) — must match ggml-quants.c exactly
+static constexpr int8_t TQ3_SIGNS[32] = {
+    +1, -1, +1, +1, -1, -1, +1, -1, +1, +1, -1, +1, -1, +1, -1, -1,
+    +1, -1, -1, +1, +1, -1, +1, -1, -1, +1, +1, +1, -1, -1, +1, -1
+};
+
+// Max-Lloyd optimal centroids for N(0,1), 2-bit (4 levels)
+static constexpr float TQ3_CENTROIDS[4] = { -1.510f, -0.4528f, 0.4528f, 1.510f };
+
+static constexpr float TQ3_INV_SQRT32 = 0.17677669529663688f; // 1/sqrt(32)
+
+// Dequantize one TQ3_0 block, return elements [iqs] and [iqs+1].
+// iqs ranges 0, 2, 4, ..., 30 — same stride convention as Q8_0.
+// Decodes the full 32-element block each call (WHT mixes all values).
+// Per-call cost: 32 centroid lookups + 5-stage butterfly + 32 scale+sign ops.
+// Wasteful in theory, but all ops are register-only — no extra memory traffic.
+static __dpct_inline__ void dequantize_tq3_0(const void * vx, const int64_t ib,
+                                             const int iqs, dfloat2 & v) {
+    const block_tq3_0 * x = (const block_tq3_0 *) vx;
+
+    const float d = sycl::vec<sycl::half, 1>(x[ib].gamma)
+                        .convert<float, sycl::rounding_mode::automatic>()[0];
+
+    // Step 1: centroid lookup → rotated space
+    float rotated[32];
+#pragma unroll
+    for (int j = 0; j < 32; j++) {
+        const int idx = (x[ib].qs[j / 4] >> (2 * (j % 4))) & 3;
+        rotated[j] = d * TQ3_CENTROIDS[idx];
+    }
+
+    // Step 2: inverse Walsh-Hadamard Transform (5 butterfly stages)
+    // WHT is self-inverse: WHT(WHT(x)) = 32*x, so one application reverses it
+    // (the 1/sqrt(32) normalization handles the factor)
+#pragma unroll
+    for (int step = 1; step < 32; step <<= 1) {
+#pragma unroll
+        for (int i = 0; i < 32; i += step * 2) {
+#pragma unroll
+            for (int jj = i; jj < i + step; jj++) {
+                float a = rotated[jj];
+                float b = rotated[jj + step];
+                rotated[jj]        = a + b;
+                rotated[jj + step] = a - b;
+            }
+        }
+    }
+
+    // Step 3: normalize and undo preconditioning sign flips
+#pragma unroll
+    for (int j = 0; j < 32; j++) {
+        rotated[j] *= TQ3_INV_SQRT32 * (float)TQ3_SIGNS[j];
+    }
+
+    v.x() = rotated[iqs];
+    v.y() = rotated[iqs + 1];
+}
+
+// Full-block dequantize kernel for ggml_type_to_float / convert operations.
+// Each work-item handles one 32-value block → 32 output floats.
+template<typename dst_t>
+static void dequantize_block_tq3_0(const void * __restrict__ vx, dst_t * __restrict__ yy,
+                                   int64_t nb32, const sycl::nd_item<3> & item_ct1) {
+    const int64_t bid = (int64_t)item_ct1.get_group(2) * item_ct1.get_local_range(2)
+                        + item_ct1.get_local_id(2);
+    if (bid >= nb32) return;
+
+    const block_tq3_0 * x = (const block_tq3_0 *) vx + bid;
+    dst_t * y = yy + bid * QK_TQ3_0;
+
+    const float d = sycl::vec<sycl::half, 1>(x->gamma)
+                        .convert<float, sycl::rounding_mode::automatic>()[0];
+
+    float rotated[32];
+#pragma unroll
+    for (int j = 0; j < 32; j++) {
+        const int idx = (x->qs[j / 4] >> (2 * (j % 4))) & 3;
+        rotated[j] = d * TQ3_CENTROIDS[idx];
+    }
+
+#pragma unroll
+    for (int step = 1; step < 32; step <<= 1) {
+#pragma unroll
+        for (int i = 0; i < 32; i += step * 2) {
+#pragma unroll
+            for (int jj = i; jj < i + step; jj++) {
+                float a = rotated[jj];
+                float b = rotated[jj + step];
+                rotated[jj]        = a + b;
+                rotated[jj + step] = a - b;
+            }
+        }
+    }
+
+#pragma unroll
+    for (int j = 0; j < 32; j++) {
+        y[j] = (dst_t)(rotated[j] * TQ3_INV_SQRT32 * (float)TQ3_SIGNS[j]);
+    }
+}
 #endif // GGML_SYCL_DEQUANTIZE_HPP

--- a/ggml/src/ggml-sycl/dmmv.cpp
+++ b/ggml/src/ggml-sycl/dmmv.cpp
@@ -992,6 +992,7 @@ static void dequantize_mul_mat_vec_q8_0_sycl(const void *vx, const dfloat *y,
             });
     }
 }
+static void dequantize_mul_mat_vec_tq3_0_sycl(const void *vx, const dfloat *y,                                              float *dst, const int ncols,                                              const int nrows,                                              dpct::queue_ptr stream) {    GGML_ASSERT(ncols % GGML_SYCL_DMMV_X == 0);    const int block_num_y = (nrows + GGML_SYCL_MMV_Y - 1) / GGML_SYCL_MMV_Y;    const sycl::range<3> block_nums(1, 1, block_num_y);    const sycl::range<3> block_dims(1, GGML_SYCL_MMV_Y, WARP_SIZE);    {        dpct::has_capability_or_fail(stream->get_device(), {sycl::aspect::fp16});        stream->parallel_for(            sycl::nd_range<3>(block_nums * block_dims, block_dims),            [=](sycl::nd_item<3> item_ct1) [[sycl::reqd_sub_group_size(WARP_SIZE)]] {                dequantize_mul_mat_vec<QK_TQ3_0, QR_TQ3_0, dequantize_tq3_0>(                    vx, y, dst, ncols, nrows, item_ct1);            });    }}
 
 static void dequantize_mul_mat_vec_q2_K_sycl(const void *vx, const float *y,
                                              float *dst, const int ncols,
@@ -1089,7 +1090,8 @@ void ggml_sycl_op_dequantize_mul_mat_vec(
     bool src1_convert_f16 =
         src0->type == GGML_TYPE_Q4_0 || src0->type == GGML_TYPE_Q4_1 ||
         src0->type == GGML_TYPE_Q5_0 || src0->type == GGML_TYPE_Q5_1 ||
-        src0->type == GGML_TYPE_Q8_0 || src0->type == GGML_TYPE_F16;
+        src0->type == GGML_TYPE_Q8_0 || src0->type == GGML_TYPE_F16 ||
+        src0->type == GGML_TYPE_TQ3_0;
 
     if (src1_convert_f16) {
         scope_op_debug_print scope_dbg_print(__func__, "/to_fp16_sycl", dst, /*num_src=*/2,
@@ -1123,6 +1125,7 @@ void ggml_sycl_op_dequantize_mul_mat_vec(
             break;
         case GGML_TYPE_Q8_0:
             dequantize_mul_mat_vec_q8_0_sycl(src0_dd_i, src1_dfloat, dst_dd_i, ne00, row_diff, stream);
+            break;        case GGML_TYPE_TQ3_0:            dequantize_mul_mat_vec_tq3_0_sycl(src0_dd_i, src1_dfloat, dst_dd_i, ne00, row_diff, stream);
             break;
         case GGML_TYPE_Q2_K:
             dequantize_mul_mat_vec_q2_K_sycl(src0_dd_i, src1_ddf_i, dst_dd_i, ne00, row_diff, stream);

--- a/ggml/src/ggml-sycl/ggml-sycl.cpp
+++ b/ggml/src/ggml-sycl/ggml-sycl.cpp
@@ -780,6 +780,7 @@ static int64_t get_row_rounding(ggml_type type, const std::array<float, GGML_SYC
         case GGML_TYPE_Q5_0:
         case GGML_TYPE_Q5_1:
         case GGML_TYPE_Q8_0:
+        case GGML_TYPE_TQ3_0:
             return 64;
         case GGML_TYPE_F16:
         case GGML_TYPE_F32:

--- a/ggml/src/ggml-vulkan/ggml-vulkan.cpp
+++ b/ggml/src/ggml-vulkan/ggml-vulkan.cpp
@@ -3437,11 +3437,13 @@ static void ggml_vk_load_shaders(vk_device& device) {
         CREATE_FA(GGML_TYPE_F16, f16, FA_SCALAR, )
         CREATE_FA(GGML_TYPE_Q4_0, q4_0, FA_SCALAR, )
         CREATE_FA(GGML_TYPE_Q8_0, q8_0, FA_SCALAR, )
+        CREATE_FA(GGML_TYPE_TQ3_0, tq3_0, FA_SCALAR, )
     } else {
         CREATE_FA(GGML_TYPE_F32, f32, FA_SCALAR, _fp32)
         CREATE_FA(GGML_TYPE_F16, f16, FA_SCALAR, _fp32)
         CREATE_FA(GGML_TYPE_Q4_0, q4_0, FA_SCALAR, _fp32)
         CREATE_FA(GGML_TYPE_Q8_0, q8_0, FA_SCALAR, _fp32)
+        CREATE_FA(GGML_TYPE_TQ3_0, tq3_0, FA_SCALAR, _fp32)
     }
 #if defined(VK_KHR_cooperative_matrix) && defined(GGML_VULKAN_COOPMAT_GLSLC_SUPPORT)
     if (device->coopmat1_fa_support) {
@@ -4048,7 +4050,7 @@ static void ggml_vk_load_shaders(vk_device& device) {
             ggml_vk_create_pipeline(device, device->pipeline_dequant_mul_mat_vec_f32_f32[w][GGML_TYPE_IQ3_S][i],   "mul_mat_vec_iq3_s_f32_f32",   arr_dmmv_iq3_s_f32_f32_len[reduc16],   arr_dmmv_iq3_s_f32_f32_data[reduc16],   "main", mul_mat_vec_num_bindings, sizeof(vk_mat_vec_push_constants), {rm_iq, 1, 1}, {wg_size_subgroup16, rm_iq, i+1}, 1, true, use_subgroups16, force_subgroup_size16);
             ggml_vk_create_pipeline(device, device->pipeline_dequant_mul_mat_vec_f32_f32[w][GGML_TYPE_IQ4_XS][i],  "mul_mat_vec_iq4_xs_f32_f32",  arr_dmmv_iq4_xs_f32_f32_len[reduc16],  arr_dmmv_iq4_xs_f32_f32_data[reduc16],  "main", mul_mat_vec_num_bindings, sizeof(vk_mat_vec_push_constants), {rm_iq, 1, 1}, {wg_size_subgroup16, rm_iq, i+1}, 1, true, use_subgroups16, force_subgroup_size16);
             ggml_vk_create_pipeline(device, device->pipeline_dequant_mul_mat_vec_f32_f32[w][GGML_TYPE_IQ4_NL][i],  "mul_mat_vec_iq4_nl_f32_f32",  arr_dmmv_iq4_nl_f32_f32_len[reduc16],  arr_dmmv_iq4_nl_f32_f32_data[reduc16],  "main", mul_mat_vec_num_bindings, sizeof(vk_mat_vec_push_constants), {rm_iq, 1, 1}, {wg_size_subgroup16, rm_iq, i+1}, 1, true, use_subgroups16, force_subgroup_size16);
-            ggml_vk_create_pipeline(device, device->pipeline_dequant_mul_mat_vec_f32_f32[w][GGML_TYPE_MXFP4][i],   "mul_mat_vec_mxfp4_f32_f32",   arr_dmmv_mxfp4_f32_f32_len[reduc16],   arr_dmmv_mxfp4_f32_f32_data[reduc16],   "main", mul_mat_vec_num_bindings, sizeof(vk_mat_vec_push_constants), {rm_iq, 1, 1}, {wg_size_subgroup16, rm_iq, i+1}, 1, true, use_subgroups16, force_subgroup_size16);
+            ggml_vk_create_pipeline(device, device->pipeline_dequant_mul_mat_vec_f32_f32[w][GGML_TYPE_MXFP4][i],   "mul_mat_vec_mxfp4_f32_f32",   arr_dmmv_mxfp4_f32_f32_len[reduc16],   arr_dmmv_mxfp4_f32_f32_data[reduc16],   "main", mul_mat_vec_num_bindings, sizeof(vk_mat_vec_push_constants), {rm_iq, 1, 1}, {wg_size_subgroup16, rm_iq, i+1}, 1, true, use_subgroups16, force_subgroup_size16);            ggml_vk_create_pipeline(device, device->pipeline_dequant_mul_mat_vec_f32_f32[w][GGML_TYPE_TQ3_0][i],  "mul_mat_vec_tq3_0_f32_f32",  arr_dmmv_tq3_0_f32_f32_len[reduc],  arr_dmmv_tq3_0_f32_f32_data[reduc],  "main", mul_mat_vec_num_bindings, sizeof(vk_mat_vec_push_constants), {rm_stdq, 1, 1}, {wg_size_subgroup, rm_stdq, i+1}, 1, true, use_subgroups, force_subgroup_size);
 
             ggml_vk_create_pipeline(device, device->pipeline_dequant_mul_mat_vec_f16_f32[w][GGML_TYPE_F32 ][i], "mul_mat_vec_f32_f16_f32",  arr_dmmv_f32_f16_f32_len[reduc],  arr_dmmv_f32_f16_f32_data[reduc],  "main", mul_mat_vec_num_bindings, sizeof(vk_mat_vec_push_constants), {1, 1, 1}, {wg_size_subgroup, 1, i+1}, 1, false, use_subgroups, force_subgroup_size);
             ggml_vk_create_pipeline(device, device->pipeline_dequant_mul_mat_vec_f16_f32[w][GGML_TYPE_F16 ][i], "mul_mat_vec_f16_f16_f32",  arr_dmmv_f16_f16_f32_len[reduc],  arr_dmmv_f16_f16_f32_data[reduc],  "main", mul_mat_vec_num_bindings, sizeof(vk_mat_vec_push_constants), {2, 1, 1}, {wg_size_subgroup, 2, i+1}, 1, false, use_subgroups, force_subgroup_size);
@@ -4072,7 +4074,7 @@ static void ggml_vk_load_shaders(vk_device& device) {
             ggml_vk_create_pipeline(device, device->pipeline_dequant_mul_mat_vec_f16_f32[w][GGML_TYPE_IQ3_S][i],   "mul_mat_vec_iq3_s_f16_f32",   arr_dmmv_iq3_s_f16_f32_len[reduc16],   arr_dmmv_iq3_s_f16_f32_data[reduc16],   "main", mul_mat_vec_num_bindings, sizeof(vk_mat_vec_push_constants), {rm_iq, 1, 1}, {wg_size_subgroup16, rm_iq, i+1}, 1, true, use_subgroups16, force_subgroup_size16);
             ggml_vk_create_pipeline(device, device->pipeline_dequant_mul_mat_vec_f16_f32[w][GGML_TYPE_IQ4_XS][i],  "mul_mat_vec_iq4_xs_f16_f32",  arr_dmmv_iq4_xs_f16_f32_len[reduc16],  arr_dmmv_iq4_xs_f16_f32_data[reduc16],  "main", mul_mat_vec_num_bindings, sizeof(vk_mat_vec_push_constants), {rm_iq, 1, 1}, {wg_size_subgroup16, rm_iq, i+1}, 1, true, use_subgroups16, force_subgroup_size16);
             ggml_vk_create_pipeline(device, device->pipeline_dequant_mul_mat_vec_f16_f32[w][GGML_TYPE_IQ4_NL][i],  "mul_mat_vec_iq4_nl_f16_f32",  arr_dmmv_iq4_nl_f16_f32_len[reduc16],  arr_dmmv_iq4_nl_f16_f32_data[reduc16],  "main", mul_mat_vec_num_bindings, sizeof(vk_mat_vec_push_constants), {rm_iq, 1, 1}, {wg_size_subgroup16, rm_iq, i+1}, 1, true, use_subgroups16, force_subgroup_size16);
-            ggml_vk_create_pipeline(device, device->pipeline_dequant_mul_mat_vec_f16_f32[w][GGML_TYPE_MXFP4][i],   "mul_mat_vec_mxfp4_f16_f32",   arr_dmmv_mxfp4_f16_f32_len[reduc16],   arr_dmmv_mxfp4_f16_f32_data[reduc16],   "main", mul_mat_vec_num_bindings, sizeof(vk_mat_vec_push_constants), {rm_iq, 1, 1}, {wg_size_subgroup16, rm_iq, i+1}, 1, true, use_subgroups16, force_subgroup_size16);
+            ggml_vk_create_pipeline(device, device->pipeline_dequant_mul_mat_vec_f16_f32[w][GGML_TYPE_MXFP4][i],   "mul_mat_vec_mxfp4_f16_f32",   arr_dmmv_mxfp4_f16_f32_len[reduc16],   arr_dmmv_mxfp4_f16_f32_data[reduc16],   "main", mul_mat_vec_num_bindings, sizeof(vk_mat_vec_push_constants), {rm_iq, 1, 1}, {wg_size_subgroup16, rm_iq, i+1}, 1, true, use_subgroups16, force_subgroup_size16);            ggml_vk_create_pipeline(device, device->pipeline_dequant_mul_mat_vec_f16_f32[w][GGML_TYPE_TQ3_0][i],  "mul_mat_vec_tq3_0_f16_f32",  arr_dmmv_tq3_0_f16_f32_len[reduc],  arr_dmmv_tq3_0_f16_f32_data[reduc],  "main", mul_mat_vec_num_bindings, sizeof(vk_mat_vec_push_constants), {rm_stdq, 1, 1}, {wg_size_subgroup, rm_stdq, i+1}, 1, true, use_subgroups, force_subgroup_size);
 
 #if defined(GGML_VULKAN_INTEGER_DOT_GLSLC_SUPPORT)
             if (device->integer_dot_product) {
@@ -4122,6 +4124,7 @@ static void ggml_vk_load_shaders(vk_device& device) {
         ggml_vk_create_pipeline(device, device->pipeline_dequant_mul_mat_vec_id_f32[w][GGML_TYPE_IQ3_S],   "mul_mat_vec_id_iq3_s_f32",   arr_dmmv_id_iq3_s_f32_f32_len[reduc16],   arr_dmmv_id_iq3_s_f32_f32_data[reduc16],   "main", mul_mat_vec_id_num_bindings, sizeof(vk_mat_vec_id_push_constants), {rm_iq, 1, 1}, {wg_size_subgroup16, rm_iq}, 1, true, use_subgroups16, force_subgroup_size16);
         ggml_vk_create_pipeline(device, device->pipeline_dequant_mul_mat_vec_id_f32[w][GGML_TYPE_IQ4_XS],  "mul_mat_vec_id_iq4_xs_f32",  arr_dmmv_id_iq4_xs_f32_f32_len[reduc16],  arr_dmmv_id_iq4_xs_f32_f32_data[reduc16],  "main", mul_mat_vec_id_num_bindings, sizeof(vk_mat_vec_id_push_constants), {rm_iq, 1, 1}, {wg_size_subgroup16, rm_iq}, 1, true, use_subgroups16, force_subgroup_size16);
         ggml_vk_create_pipeline(device, device->pipeline_dequant_mul_mat_vec_id_f32[w][GGML_TYPE_IQ4_NL],  "mul_mat_vec_id_iq4_nl_f32",  arr_dmmv_id_iq4_nl_f32_f32_len[reduc16],  arr_dmmv_id_iq4_nl_f32_f32_data[reduc16],  "main", mul_mat_vec_id_num_bindings, sizeof(vk_mat_vec_id_push_constants), {rm_iq, 1, 1}, {wg_size_subgroup16, rm_iq}, 1, true, use_subgroups16, force_subgroup_size16);
+        ggml_vk_create_pipeline(device, device->pipeline_dequant_mul_mat_vec_id_f32[w][GGML_TYPE_TQ3_0],  "mul_mat_vec_id_tq3_0_f32",  arr_dmmv_id_tq3_0_f32_f32_len[reduc],  arr_dmmv_id_tq3_0_f32_f32_data[reduc],  "main", mul_mat_vec_id_num_bindings, sizeof(vk_mat_vec_id_push_constants), {rm_stdq, 1, 1}, {wg_size_subgroup, rm_stdq}, 1, true, use_subgroups, force_subgroup_size);
         ggml_vk_create_pipeline(device, device->pipeline_dequant_mul_mat_vec_id_f32[w][GGML_TYPE_MXFP4],   "mul_mat_vec_id_mxfp4_f32",   arr_dmmv_id_mxfp4_f32_f32_len[reduc16],   arr_dmmv_id_mxfp4_f32_f32_data[reduc16],   "main", mul_mat_vec_id_num_bindings, sizeof(vk_mat_vec_id_push_constants), {rm_iq, 1, 1}, {wg_size_subgroup16, rm_iq}, 1, true, use_subgroups16, force_subgroup_size16);
 
 #if defined(GGML_VULKAN_INTEGER_DOT_GLSLC_SUPPORT)
@@ -4162,6 +4165,7 @@ static void ggml_vk_load_shaders(vk_device& device) {
     ggml_vk_create_pipeline(device, device->pipeline_dequant[GGML_TYPE_Q5_0], "dequant_q5_0", dequant_q5_0_len, dequant_q5_0_data, "main", 2, 5 * sizeof(uint32_t), {256 * 16, 1, 1}, {}, 1);
     ggml_vk_create_pipeline(device, device->pipeline_dequant[GGML_TYPE_Q5_1], "dequant_q5_1", dequant_q5_1_len, dequant_q5_1_data, "main", 2, 5 * sizeof(uint32_t), {256 * 16, 1, 1}, {}, 1);
     ggml_vk_create_pipeline(device, device->pipeline_dequant[GGML_TYPE_Q8_0], "dequant_q8_0", dequant_q8_0_len, dequant_q8_0_data, "main", 2, 5 * sizeof(uint32_t), {256 * 16, 1, 1}, {}, 1);
+    ggml_vk_create_pipeline(device, device->pipeline_dequant[GGML_TYPE_TQ3_0], "dequant_tq3_0", dequant_tq3_0_len, dequant_tq3_0_data, "main", 2, 5 * sizeof(uint32_t), {256 * 32, 1, 1}, {}, 1);
     ggml_vk_create_pipeline(device, device->pipeline_dequant[GGML_TYPE_Q2_K], "dequant_q2_k", dequant_q2_k_len, dequant_q2_k_data, "main", 2, 5 * sizeof(uint32_t), {256 * 64, 1, 1}, {}, 1);
     ggml_vk_create_pipeline(device, device->pipeline_dequant[GGML_TYPE_Q3_K], "dequant_q3_k", dequant_q3_k_len, dequant_q3_k_data, "main", 2, 5 * sizeof(uint32_t), {256 * 64, 1, 1}, {}, 1);
     ggml_vk_create_pipeline(device, device->pipeline_dequant[GGML_TYPE_Q4_K], "dequant_q4_k", dequant_q4_k_len, dequant_q4_k_data, "main", 2, 5 * sizeof(uint32_t), {256 * 32, 1, 1}, {}, 1);
@@ -4294,14 +4298,16 @@ static void ggml_vk_load_shaders(vk_device& device) {
         ggml_vk_create_pipeline(device, device->pipeline_cpy_f32_quant[GGML_TYPE_Q5_1], "cpy_f32_q5_1", cpy_f32_q5_1_rte_len, cpy_f32_q5_1_rte_data, "main", 2, sizeof(vk_op_unary_push_constants), {32, 1, 1}, {}, 1);
         ggml_vk_create_pipeline(device, device->pipeline_cpy_f32_quant[GGML_TYPE_Q8_0], "cpy_f32_q8_0", cpy_f32_q8_0_rte_len, cpy_f32_q8_0_rte_data, "main", 2, sizeof(vk_op_unary_push_constants), {32, 1, 1}, {}, 1);
         ggml_vk_create_pipeline(device, device->pipeline_cpy_f32_quant[GGML_TYPE_IQ4_NL], "cpy_f32_iq4_nl", cpy_f32_iq4_nl_rte_len, cpy_f32_iq4_nl_rte_data, "main", 2, sizeof(vk_op_unary_push_constants), {32, 1, 1}, {}, 1);
-    } else {
+        ggml_vk_create_pipeline(device, device->pipeline_cpy_f32_quant[GGML_TYPE_TQ3_0], "cpy_f32_tq3_0", cpy_f32_tq3_0_rte_len, cpy_f32_tq3_0_rte_data, "main", 2, sizeof(vk_op_unary_push_constants), {32, 1, 1}, {}, 1);
+        } else {
         ggml_vk_create_pipeline(device, device->pipeline_cpy_f32_quant[GGML_TYPE_Q4_0], "cpy_f32_q4_0", cpy_f32_q4_0_len, cpy_f32_q4_0_data, "main", 2, sizeof(vk_op_unary_push_constants), {32, 1, 1}, {}, 1);
         ggml_vk_create_pipeline(device, device->pipeline_cpy_f32_quant[GGML_TYPE_Q4_1], "cpy_f32_q4_1", cpy_f32_q4_1_len, cpy_f32_q4_1_data, "main", 2, sizeof(vk_op_unary_push_constants), {32, 1, 1}, {}, 1);
         ggml_vk_create_pipeline(device, device->pipeline_cpy_f32_quant[GGML_TYPE_Q5_0], "cpy_f32_q5_0", cpy_f32_q5_0_len, cpy_f32_q5_0_data, "main", 2, sizeof(vk_op_unary_push_constants), {32, 1, 1}, {}, 1);
         ggml_vk_create_pipeline(device, device->pipeline_cpy_f32_quant[GGML_TYPE_Q5_1], "cpy_f32_q5_1", cpy_f32_q5_1_len, cpy_f32_q5_1_data, "main", 2, sizeof(vk_op_unary_push_constants), {32, 1, 1}, {}, 1);
         ggml_vk_create_pipeline(device, device->pipeline_cpy_f32_quant[GGML_TYPE_Q8_0], "cpy_f32_q8_0", cpy_f32_q8_0_len, cpy_f32_q8_0_data, "main", 2, sizeof(vk_op_unary_push_constants), {32, 1, 1}, {}, 1);
         ggml_vk_create_pipeline(device, device->pipeline_cpy_f32_quant[GGML_TYPE_IQ4_NL], "cpy_f32_iq4_nl", cpy_f32_iq4_nl_len, cpy_f32_iq4_nl_data, "main", 2, sizeof(vk_op_unary_push_constants), {32, 1, 1}, {}, 1);
-    }
+        ggml_vk_create_pipeline(device, device->pipeline_cpy_f32_quant[GGML_TYPE_TQ3_0], "cpy_f32_tq3_0", cpy_f32_tq3_0_len, cpy_f32_tq3_0_data, "main", 2, sizeof(vk_op_unary_push_constants), {32, 1, 1}, {}, 1);
+        }
 
 #define SET_ROWS(itype, rte) \
         ggml_vk_create_pipeline(device, device->pipeline_set_rows ## itype [GGML_TYPE_F32],  "set_rows_f32" #itype,  set_rows_f32 ## itype ## rte ## _len,  set_rows_f32 ## itype ## rte ## _data,  "main", 3, sizeof(vk_op_binary_push_constants), {1, 1, 1}, {1}, 1, true); \
@@ -4312,7 +4318,8 @@ static void ggml_vk_load_shaders(vk_device& device) {
         ggml_vk_create_pipeline(device, device->pipeline_set_rows ## itype [GGML_TYPE_Q5_0], "set_rows_q5_0" #itype, set_rows_q5_0 ## itype ## rte ## _len, set_rows_q5_0 ## itype ## rte ## _data, "main", 3, sizeof(vk_op_binary_push_constants), {1, 1, 1}, {1}, 1, true); \
         ggml_vk_create_pipeline(device, device->pipeline_set_rows ## itype [GGML_TYPE_Q5_1], "set_rows_q5_1" #itype, set_rows_q5_1 ## itype ## rte ## _len, set_rows_q5_1 ## itype ## rte ## _data, "main", 3, sizeof(vk_op_binary_push_constants), {1, 1, 1}, {1}, 1, true); \
         ggml_vk_create_pipeline(device, device->pipeline_set_rows ## itype [GGML_TYPE_Q8_0], "set_rows_q8_0" #itype, set_rows_q8_0 ## itype ## rte ## _len, set_rows_q8_0 ## itype ## rte ## _data, "main", 3, sizeof(vk_op_binary_push_constants), {1, 1, 1}, {1}, 1, true); \
-        ggml_vk_create_pipeline(device, device->pipeline_set_rows ## itype [GGML_TYPE_IQ4_NL], "set_rows_iq4_nl" #itype, set_rows_iq4_nl ## itype ## rte ## _len, set_rows_iq4_nl ## itype ## rte ## _data, "main", 3, sizeof(vk_op_binary_push_constants), {1, 1, 1}, {1}, 1, true);
+        ggml_vk_create_pipeline(device, device->pipeline_set_rows ## itype [GGML_TYPE_IQ4_NL], "set_rows_iq4_nl" #itype, set_rows_iq4_nl ## itype ## rte ## _len, set_rows_iq4_nl ## itype ## rte ## _data, "main", 3, sizeof(vk_op_binary_push_constants), {1, 1, 1}, {1}, 1, true); \
+        ggml_vk_create_pipeline(device, device->pipeline_set_rows ## itype [GGML_TYPE_TQ3_0], "set_rows_tq3_0" #itype, set_rows_tq3_0 ## itype ## rte ## _len, set_rows_tq3_0 ## itype ## rte ## _data, "main", 3, sizeof(vk_op_binary_push_constants), {1, 1, 1}, {1}, 1, true);
 
     if (device->float_controls_rte_fp16) {
         SET_ROWS(_i32, _rte)
@@ -4330,6 +4337,7 @@ static void ggml_vk_load_shaders(vk_device& device) {
     ggml_vk_create_pipeline(device, device->pipeline_cpy_quant_f32[GGML_TYPE_Q5_1], "cpy_q5_1_f32", cpy_q5_1_f32_len, cpy_q5_1_f32_data, "main", 2, sizeof(vk_op_unary_push_constants), {(uint32_t)ggml_blck_size(GGML_TYPE_Q5_1), 1, 1}, {}, 1);
     ggml_vk_create_pipeline(device, device->pipeline_cpy_quant_f32[GGML_TYPE_Q8_0], "cpy_q8_0_f32", cpy_q8_0_f32_len, cpy_q8_0_f32_data, "main", 2, sizeof(vk_op_unary_push_constants), {(uint32_t)ggml_blck_size(GGML_TYPE_Q8_0), 1, 1}, {}, 1);
     ggml_vk_create_pipeline(device, device->pipeline_cpy_quant_f32[GGML_TYPE_IQ4_NL], "cpy_iq4_nl_f32", cpy_iq4_nl_f32_len, cpy_iq4_nl_f32_data, "main", 2, sizeof(vk_op_unary_push_constants), {(uint32_t)ggml_blck_size(GGML_TYPE_IQ4_NL), 1, 1}, {}, 1);
+    ggml_vk_create_pipeline(device, device->pipeline_cpy_quant_f32[GGML_TYPE_TQ3_0], "cpy_tq3_0_f32", cpy_tq3_0_f32_len, cpy_tq3_0_f32_data, "main", 2, sizeof(vk_op_unary_push_constants), {(uint32_t)ggml_blck_size(GGML_TYPE_TQ3_0), 1, 1}, {}, 1);
 
     auto get_suffix = [](bool src0_f16, bool src1_f16, bool dst_f16) {
         std::string s;
@@ -6007,6 +6015,7 @@ static vk_pipeline ggml_vk_get_to_fp16(ggml_backend_vk_context * ctx, ggml_type 
         case GGML_TYPE_Q5_0:
         case GGML_TYPE_Q5_1:
         case GGML_TYPE_Q8_0:
+        case GGML_TYPE_TQ3_0:
         case GGML_TYPE_Q2_K:
         case GGML_TYPE_Q3_K:
         case GGML_TYPE_Q4_K:
@@ -6078,6 +6087,7 @@ static vk_matmul_pipeline ggml_vk_get_mul_mat_mat_pipeline(ggml_backend_vk_conte
         case GGML_TYPE_Q5_0:
         case GGML_TYPE_Q5_1:
         case GGML_TYPE_Q8_0:
+        case GGML_TYPE_TQ3_0:
         case GGML_TYPE_Q2_K:
         case GGML_TYPE_Q3_K:
         case GGML_TYPE_Q4_K:
@@ -6143,6 +6153,7 @@ static vk_pipeline ggml_vk_get_dequantize_mul_mat_vec(ggml_backend_vk_context * 
         case GGML_TYPE_Q5_0:
         case GGML_TYPE_Q5_1:
         case GGML_TYPE_Q8_0:
+        case GGML_TYPE_TQ3_0:
         case GGML_TYPE_Q2_K:
         case GGML_TYPE_Q3_K:
         case GGML_TYPE_Q4_K:
@@ -6233,6 +6244,7 @@ static vk_matmul_pipeline ggml_vk_get_mul_mat_mat_id_pipeline(ggml_backend_vk_co
         case GGML_TYPE_Q5_0:
         case GGML_TYPE_Q5_1:
         case GGML_TYPE_Q8_0:
+        case GGML_TYPE_TQ3_0:
         case GGML_TYPE_Q2_K:
         case GGML_TYPE_Q3_K:
         case GGML_TYPE_Q4_K:
@@ -6301,6 +6313,7 @@ static vk_pipeline ggml_vk_get_dequantize_mul_mat_vec_id(ggml_backend_vk_context
         case GGML_TYPE_Q5_0:
         case GGML_TYPE_Q5_1:
         case GGML_TYPE_Q8_0:
+        case GGML_TYPE_TQ3_0:
         case GGML_TYPE_Q2_K:
         case GGML_TYPE_Q3_K:
         case GGML_TYPE_Q4_K:
@@ -7249,6 +7262,7 @@ static vk_pipeline ggml_vk_get_cpy_pipeline(ggml_backend_vk_context * ctx, const
         case GGML_TYPE_Q5_1:
         case GGML_TYPE_Q8_0:
         case GGML_TYPE_IQ4_NL:
+        case GGML_TYPE_TQ3_0:
             return ctx->device->pipeline_cpy_f32_quant[to];
         default:
             break;
@@ -7263,6 +7277,7 @@ static vk_pipeline ggml_vk_get_cpy_pipeline(ggml_backend_vk_context * ctx, const
         case GGML_TYPE_Q5_1:
         case GGML_TYPE_Q8_0:
         case GGML_TYPE_IQ4_NL:
+        case GGML_TYPE_TQ3_0:
             return ctx->device->pipeline_cpy_quant_f32[src->type];
         default:
             break;
@@ -15258,6 +15273,7 @@ static bool ggml_backend_vk_device_supports_op(ggml_backend_dev_t dev, const ggm
                     case GGML_TYPE_IQ4_XS:
                     case GGML_TYPE_IQ4_NL:
                     case GGML_TYPE_MXFP4:
+                    case GGML_TYPE_TQ3_0:
                         break;
                     default:
                         return false;
@@ -15317,6 +15333,9 @@ static bool ggml_backend_vk_device_supports_op(ggml_backend_dev_t dev, const ggm
                 case GGML_TYPE_Q4_0:
                 case GGML_TYPE_Q8_0:
                     // supported in scalar and coopmat2 paths
+                    break;
+                case GGML_TYPE_TQ3_0:
+                    // supported in scalar path only
                     break;
                 case GGML_TYPE_Q4_1:
                 case GGML_TYPE_Q5_0:
@@ -15394,6 +15413,7 @@ static bool ggml_backend_vk_device_supports_op(ggml_backend_dev_t dev, const ggm
                     case GGML_TYPE_Q5_1:
                     case GGML_TYPE_Q8_0:
                     case GGML_TYPE_IQ4_NL:
+                    case GGML_TYPE_TQ3_0:
                         return true;
                     default:
                         return false;
@@ -15417,6 +15437,7 @@ static bool ggml_backend_vk_device_supports_op(ggml_backend_dev_t dev, const ggm
                     case GGML_TYPE_Q5_1:
                     case GGML_TYPE_Q8_0:
                     case GGML_TYPE_IQ4_NL:
+                    case GGML_TYPE_TQ3_0:
                         return true;
                     default:
                         break;
@@ -15431,6 +15452,7 @@ static bool ggml_backend_vk_device_supports_op(ggml_backend_dev_t dev, const ggm
                     case GGML_TYPE_Q5_1:
                     case GGML_TYPE_Q8_0:
                     case GGML_TYPE_IQ4_NL:
+                    case GGML_TYPE_TQ3_0:
                         return true;
                     default:
                         break;

--- a/ggml/src/ggml-vulkan/vulkan-shaders/copy_to_quant.comp
+++ b/ggml/src/ggml-vulkan/vulkan-shaders/copy_to_quant.comp
@@ -246,6 +246,63 @@ void quantize(uint dst_idx, uint src_idx)
 }
 #endif
 
+
+#if defined(DATA_A_TQ3_0)
+void quantize(uint dst_idx, uint src_idx)
+{
+    const float INV_SQRT32 = 0.17677669529663688;
+    const float CENTROIDS[4] = float[4](-1.510, -0.4528, 0.4528, 1.510);
+    const float SIGNS[32] = float[32](
+        1.0,-1.0, 1.0, 1.0,-1.0,-1.0, 1.0,-1.0,
+        1.0, 1.0,-1.0, 1.0,-1.0, 1.0,-1.0,-1.0,
+        1.0,-1.0,-1.0, 1.0, 1.0,-1.0, 1.0,-1.0,
+       -1.0, 1.0, 1.0, 1.0,-1.0,-1.0, 1.0,-1.0
+    );
+
+    float x[32];
+    [[unroll]] for (int j = 0; j < 32; j++) {
+        x[j] = data_s[src_idx + j] * SIGNS[j];
+    }
+
+    // Forward WHT (same butterfly as decode)
+    [[unroll]] for (int step = 1; step < 32; step <<= 1) {
+        [[unroll]] for (int i = 0; i < 32; i += step * 2) {
+            [[unroll]] for (int jj = i; jj < i + step; jj++) {
+                float a = x[jj], b = x[jj + step];
+                x[jj] = a + b; x[jj + step] = a - b;
+            }
+        }
+    }
+
+    // Scale to WHT-normalized domain (matches decode 1/sqrt(32) path)
+    [[unroll]] for (int j = 0; j < 32; j++) x[j] *= INV_SQRT32;
+
+    // Compute gamma (max-abs / max-centroid)
+    float amax = 0.0;
+    [[unroll]] for (int j = 0; j < 32; j++) amax = max(amax, abs(x[j]));
+    const float d = amax / 1.510;
+    const float id = (d != 0.0) ? 1.0 / d : 0.0;
+    data_q[dst_idx].gamma = float16_t(d);
+
+    // Nearest centroid search, pack 4x 2-bit per byte
+    [[unroll]] for (int b = 0; b < 8; b++) {
+        uint packed = 0;
+        [[unroll]] for (int k = 0; k < 4; k++) {
+            float v = x[b * 4 + k] * id;
+            int best = 0;
+            float best_d = abs(v - CENTROIDS[0]);
+            [[unroll]] for (int m = 1; m < 4; m++) {
+                float dd = abs(v - CENTROIDS[m]);
+                if (dd < best_d) { best_d = dd; best = m; }
+            }
+            packed |= uint(best) << (k * 2);
+        }
+        data_q[dst_idx].qs[b] = uint8_t(packed);
+    }
+    [[unroll]] for (int b = 0; b < 4; b++) data_q[dst_idx].qr[b] = uint8_t(0);
+}
+#endif
+
 #if defined(SET_ROWS)
 
 void main() {

--- a/ggml/src/ggml-vulkan/vulkan-shaders/dequant_funcs.glsl
+++ b/ggml/src/ggml-vulkan/vulkan-shaders/dequant_funcs.glsl
@@ -602,3 +602,44 @@ vec2 get_dm(uint ib, uint a_offset) {
     return vec2(1, 0);
 }
 #endif
+
+#if defined(DATA_A_TQ3_0)
+// Decode full TQ3_0 block, return 4 elements at iqs
+// iqs called with 0, 4, 8, ..., 28 (by copy_from_quant) or 0, 1, ..., 30 (by mul_mat_vec)
+const float TQ3_FUNCS_CENTROIDS[4] = float[4](-1.510, -0.4528, 0.4528, 1.510);
+const float TQ3_FUNCS_SIGNS[32] = float[32](
+    1.0,-1.0, 1.0, 1.0,-1.0,-1.0, 1.0,-1.0, 1.0, 1.0,-1.0, 1.0,-1.0, 1.0,-1.0,-1.0,
+    1.0,-1.0,-1.0, 1.0, 1.0,-1.0, 1.0,-1.0,-1.0, 1.0, 1.0, 1.0,-1.0,-1.0, 1.0,-1.0
+);
+const float TQ3_FUNCS_INV_SQRT32 = 0.17677669529663688;
+float tq3_decode_all[32] = float[32](0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0);
+void tq3_decode(uint ib, uint a_offset) {
+    const float d = float(data_a[a_offset + ib].gamma);
+    [[unroll]] for (uint j = 0u; j < 32u; j++) {
+        uint idx = (uint(data_a[a_offset + ib].qs[j/4u]) >> ((j%4u)*2u)) & 3u;
+        tq3_decode_all[j] = d * TQ3_FUNCS_CENTROIDS[idx];
+    }
+    [[unroll]] for (uint step = 1u; step < 32u; step <<= 1u) {
+        [[unroll]] for (uint i = 0u; i < 32u; i += step * 2u) {
+            [[unroll]] for (uint jj = i; jj < i + step; jj++) {
+                float a = tq3_decode_all[jj], b = tq3_decode_all[jj+step];
+                tq3_decode_all[jj] = a+b; tq3_decode_all[jj+step] = a-b;
+            }
+        }
+    }
+    [[unroll]] for (uint j = 0u; j < 32u; j++)
+        tq3_decode_all[j] *= TQ3_FUNCS_INV_SQRT32 * TQ3_FUNCS_SIGNS[j];
+}
+vec2 dequantize(uint ib, uint iqs, uint a_offset) {
+    tq3_decode(ib, a_offset);
+    return vec2(tq3_decode_all[iqs], tq3_decode_all[iqs + 1u]);
+}
+vec4 dequantize4(uint ib, uint iqs, uint a_offset) {
+    tq3_decode(ib, a_offset);
+    return vec4(tq3_decode_all[iqs], tq3_decode_all[iqs+1u], tq3_decode_all[iqs+2u], tq3_decode_all[iqs+3u]);
+}
+vec2 get_dm(uint ib, uint a_offset) {
+    return vec2(1.0, 0.0);  // values already fully decoded in dequantize/dequantize4
+}
+#endif
+

--- a/ggml/src/ggml-vulkan/vulkan-shaders/dequant_tq3_0.comp
+++ b/ggml/src/ggml-vulkan/vulkan-shaders/dequant_tq3_0.comp
@@ -1,0 +1,58 @@
+#version 450
+
+#include "dequant_head.glsl"
+
+// One thread per 32-value block.
+// block_tq3_0 is defined in types.glsl (included via dequant_head.glsl → types.glsl)
+// when DATA_A_TQ3_0 is defined by the build system.
+layout(local_size_x = 256, local_size_y = 1, local_size_z = 1) in;
+
+layout (binding = 0) readonly buffer A  { block_tq3_0 data_a[]; };
+layout (binding = 1) writeonly buffer D { D_TYPE data_b[]; };
+
+// Max-Lloyd optimal centroids for N(0,1), 2-bit (4 levels)
+const float TQ3_CENTROIDS[4] = float[4](-1.510, -0.4528, 0.4528, 1.510);
+
+// Fixed random sign pattern (seed 42) — must match ggml-quants.c exactly
+const float TQ3_SIGNS[32] = float[32](
+    1.0, -1.0,  1.0,  1.0, -1.0, -1.0,  1.0, -1.0,
+    1.0,  1.0, -1.0,  1.0, -1.0,  1.0, -1.0, -1.0,
+    1.0, -1.0, -1.0,  1.0,  1.0, -1.0,  1.0, -1.0,
+   -1.0,  1.0,  1.0,  1.0, -1.0, -1.0,  1.0, -1.0
+);
+
+const float INV_SQRT32 = 0.17677669529663688; // 1/sqrt(32)
+
+void main() {
+    const uint ib = gl_GlobalInvocationID.x;
+    if (ib >= p.nel / 32) return;
+
+    const float d = float(data_a[ib].gamma);
+
+    // Step 1: centroid lookup → rotated domain
+    float r[32];
+    [[unroll]] for (uint j = 0u; j < 32u; j++) {
+        uint byte_idx = j / 4u;
+        uint bit_off  = (j % 4u) * 2u;
+        uint idx = (uint(data_a[ib].qs[byte_idx]) >> bit_off) & 3u;
+        r[j] = d * TQ3_CENTROIDS[idx];
+    }
+
+    // Step 2: inverse Walsh-Hadamard Transform (5 butterfly stages)
+    [[unroll]] for (uint step = 1u; step < 32u; step <<= 1u) {
+        [[unroll]] for (uint i = 0u; i < 32u; i += step * 2u) {
+            [[unroll]] for (uint jj = i; jj < i + step; jj++) {
+                float a = r[jj];
+                float b = r[jj + step];
+                r[jj]        = a + b;
+                r[jj + step] = a - b;
+            }
+        }
+    }
+
+    // Step 3: normalize and undo preconditioning sign flips
+    const uint out_base = ib * 32u;
+    [[unroll]] for (uint j = 0u; j < 32u; j++) {
+        data_b[out_base + j] = D_TYPE(r[j] * INV_SQRT32 * TQ3_SIGNS[j]);
+    }
+}

--- a/ggml/src/ggml-vulkan/vulkan-shaders/flash_attn_base.glsl
+++ b/ggml/src/ggml-vulkan/vulkan-shaders/flash_attn_base.glsl
@@ -149,6 +149,55 @@ FLOAT_TYPEV4 dequantize4(uint ib, uint iqs, uint a_offset, uint binding_idx) {
 }
 #endif
 
+#if defined(DATA_A_TQ3_0)
+#define BLOCK_BYTE_SIZE 14
+
+const float TQ3_FA_CENTROIDS[4] = float[4](-1.510, -0.4528, 0.4528, 1.510);
+const float TQ3_FA_SIGNS[32] = float[32](
+    1.0,-1.0, 1.0, 1.0,-1.0,-1.0, 1.0,-1.0, 1.0, 1.0,-1.0, 1.0,-1.0, 1.0,-1.0,-1.0,
+    1.0,-1.0,-1.0, 1.0, 1.0,-1.0, 1.0,-1.0,-1.0, 1.0, 1.0, 1.0,-1.0,-1.0, 1.0,-1.0
+);
+const float TQ3_FA_INV_SQRT32 = 0.17677669529663688;
+
+FLOAT_TYPEV4 dequantize4(uint ib, uint iqs, uint a_offset, uint binding_idx) {
+    float vals[32];
+    // Extract 2-bit centroid indices from packed uint16 array.
+    // Original qs[8] bytes are packed as uint16_t qs[4]:
+    //   word = j/8, shift = ((j/4)&1)*8 + (j%4)*2
+    [[unroll]] for (uint j = 0u; j < 32u; j++) {
+        uint word  = j / 8u;
+        uint shift = ((j / 4u) & 1u) * 8u + (j % 4u) * 2u;
+        uint cidx;
+        if (binding_idx == BINDING_IDX_K) {
+            cidx = (uint(k_packed.k_data_packed16[a_offset + ib].qs[word]) >> shift) & 3u;
+        } else {
+            cidx = (uint(v_packed.v_data_packed16[a_offset + ib].qs[word]) >> shift) & 3u;
+        }
+        vals[j] = TQ3_FA_CENTROIDS[cidx];
+    }
+    // Scale by gamma
+    float gamma_val;
+    if (binding_idx == BINDING_IDX_K) {
+        gamma_val = float(k_packed.k_data_packed16[a_offset + ib].gamma);
+    } else {
+        gamma_val = float(v_packed.v_data_packed16[a_offset + ib].gamma);
+    }
+    [[unroll]] for (uint j = 0u; j < 32u; j++) vals[j] *= gamma_val;
+    // Inverse Walsh-Hadamard Transform (32-point butterfly)
+    [[unroll]] for (uint step = 1u; step < 32u; step <<= 1u) {
+        [[unroll]] for (uint ii = 0u; ii < 32u; ii += step * 2u) {
+            [[unroll]] for (uint jj = ii; jj < ii + step; jj++) {
+                float a = vals[jj], b = vals[jj + step];
+                vals[jj] = a + b; vals[jj + step] = a - b;
+            }
+        }
+    }
+    [[unroll]] for (uint j = 0u; j < 32u; j++)
+        vals[j] *= TQ3_FA_INV_SQRT32 * TQ3_FA_SIGNS[j];
+    return FLOAT_TYPEV4(vals[iqs], vals[iqs + 1u], vals[iqs + 2u], vals[iqs + 3u]);
+}
+#endif
+
 #define CEIL_DIV(a, b) (((a) + (b) - 1) / (b))
 
 

--- a/ggml/src/ggml-vulkan/vulkan-shaders/types.glsl
+++ b/ggml/src/ggml-vulkan/vulkan-shaders/types.glsl
@@ -188,6 +188,32 @@ struct block_q8_0_packed16
 #define DATA_A_QUANT_LEGACY
 #endif
 
+#define QUANT_K_TQ3_0 32
+#define QUANT_R_TQ3_0 1
+
+// TurboQuant TQ3_0: 2-bit codebook + 1-bit QJL residual signs + FP16 scale
+struct block_tq3_0
+{
+    uint8_t  qs[8];   // 2-bit codebook indices, 4 per byte
+    uint8_t  qr[4];   // QJL residual sign bits (unused in dequant)
+    float16_t gamma;  // per-block scale
+};
+
+struct block_tq3_0_packed16
+{
+    uint16_t qs[4];   // 8 bytes: 2-bit indices packed 4 per original byte
+    uint16_t qr[2];   // 4 bytes: QJL residual bits (unused in dequant)
+    float16_t gamma;  // 2 bytes: per-block scale
+};
+
+#if defined(DATA_A_TQ3_0)
+#define QUANT_K QUANT_K_TQ3_0
+#define QUANT_R QUANT_R_TQ3_0
+#define QUANT_AUXF 1
+#define A_TYPE block_tq3_0
+#define A_TYPE_PACKED16 block_tq3_0_packed16
+#endif
+
 #define QUANT_K_Q8_1 32
 #define QUANT_R_Q8_1 1
 

--- a/ggml/src/ggml-vulkan/vulkan-shaders/vulkan-shaders-gen.cpp
+++ b/ggml/src/ggml-vulkan/vulkan-shaders/vulkan-shaders-gen.cpp
@@ -66,6 +66,7 @@ const std::vector<std::string> type_names = {
     "iq4_nl",
     "mxfp4",
     "bf16",
+    "tq3_0",
 };
 
 enum MatMulIdType {
@@ -655,7 +656,7 @@ void process_shaders() {
                 if (tname == "f16") {
                     string_to_spv("flash_attn_f32_f16_" + tname, "flash_attn_cm1.comp",
                         merge_maps(fa_base_dict, {{"Q_TYPE", "float"}, {"D_TYPE", "float"}, {"D_TYPEV4", "vec4"}, {"COOPMAT", "1"}}), fp16, true, false, f16acc);
-                } else if (tname == "q4_0" || tname == "q8_0" || tname == "f32") {
+                } else if (tname == "q4_0" || tname == "q8_0" || tname == "f32" || tname == "tq3_0") {
                     std::string data_a_key = "DATA_A_" + to_uppercase(tname);
                     string_to_spv("flash_attn_f32_f16_" + tname, "flash_attn_cm1.comp",
                         merge_maps(fa_base_dict, {{data_a_key, "1"}, {"Q_TYPE", "float"}, {"D_TYPE", "float"}, {"D_TYPEV4", "vec4"}, {"BLOCK_SIZE", "QUANT_K_"+to_uppercase(tname)}, {"COOPMAT", "1"}}), fp16, true, false, f16acc);
@@ -666,7 +667,7 @@ void process_shaders() {
                 if (tname == "f16") {
                     string_to_spv("flash_attn_f32_f16_" + tname, "flash_attn.comp",
                         merge_maps(fa_base_dict, {{"Q_TYPE", "float"}, {"D_TYPE", "float"}, {"D_TYPEV4", "vec4"}}), fp16, false, false, f16acc);
-                } else if (tname == "q4_0" || tname == "q8_0" || tname == "f32") {
+                } else if (tname == "q4_0" || tname == "q8_0" || tname == "f32" || tname == "tq3_0") {
                     std::string data_a_key = "DATA_A_" + to_uppercase(tname);
                     string_to_spv("flash_attn_f32_f16_" + tname, "flash_attn.comp",
                         merge_maps(fa_base_dict, {{data_a_key, "1"}, {"Q_TYPE", "float"}, {"D_TYPE", "float"}, {"D_TYPEV4", "vec4"}, {"BLOCK_SIZE", "QUANT_K_"+to_uppercase(tname) }}), fp16, false, false, f16acc);
@@ -678,9 +679,9 @@ void process_shaders() {
     std::map<std::string, std::string> base_dict = {{"FLOAT_TYPE", "float"}, {"FLOAT_TYPE_VEC2", "vec2"}};
 
     for (const auto& tname : type_names) {
-        // mul mat vec
         std::string data_a_key = "DATA_A_" + to_uppercase(tname);
-        std::string shader = (string_ends_with(tname, "_k") || string_starts_with(tname, "iq1_") || string_starts_with(tname, "iq2_") || string_starts_with(tname, "iq3_")) ? "mul_mat_vec_" + tname + ".comp" : "mul_mat_vec.comp";
+        std::string shader;
+        shader = (string_ends_with(tname, "_k") || string_starts_with(tname, "iq1_") || string_starts_with(tname, "iq2_") || string_starts_with(tname, "iq3_")) ? "mul_mat_vec_" + tname + ".comp" : "mul_mat_vec.comp";
 
         string_to_spv("mul_mat_vec_" + tname + "_f32_f32", shader, merge_maps(base_dict, {{data_a_key, "1"}, {"B_TYPE", "float"}, {"B_TYPE_VEC2", "vec2"}, {"B_TYPE_VEC4", "vec4"}, {"D_TYPE", "float"}}));
         string_to_spv("mul_mat_vec_" + tname + "_f16_f32", shader, merge_maps(base_dict, {{data_a_key, "1"}, {"B_TYPE", "float16_t"}, {"B_TYPE_VEC2", "f16vec2"}, {"B_TYPE_VEC4", "f16vec4"}, {"D_TYPE", "float"}}));
@@ -757,13 +758,13 @@ void process_shaders() {
     string_to_spv("cpy_transpose_16", "copy_transpose.comp", {{"A_TYPE", "uint16_t"}, {"D_TYPE", "uint16_t"}});
     string_to_spv("cpy_transpose_32", "copy_transpose.comp", {{"A_TYPE", "uint"}, {"D_TYPE", "uint"}});
 
-    for (std::string t : {"q4_0", "q4_1", "q5_0", "q5_1", "q8_0", "iq4_nl"}) {
+    for (std::string t : {"q4_0", "q4_1", "q5_0", "q5_1", "q8_0", "iq4_nl", "tq3_0"}) {
         string_to_spv("cpy_f32_" + t, "copy_to_quant.comp", {{"DATA_A_" + to_uppercase(t), "1"}, {"D_TYPE", "float"}, {"FLOAT_TYPE", "float"}});
         string_to_spv("cpy_f32_" + t + "_rte", "copy_to_quant.comp", {{"DATA_A_" + to_uppercase(t), "1"}, {"D_TYPE", "float"}, {"FLOAT_TYPE", "float"}, {"RTE16", "1"}});
         string_to_spv("cpy_" + t + "_f32", "copy_from_quant.comp", {{"DATA_A_" + to_uppercase(t), "1"}, {"D_TYPE", "float"}, {"FLOAT_TYPE", "float"}});
     }
 
-    for (std::string t : {"f32", "f16", "bf16", "q4_0", "q4_1", "q5_0", "q5_1", "q8_0", "iq4_nl"}) {
+    for (std::string t : {"f32", "f16", "bf16", "q4_0", "q4_1", "q5_0", "q5_1", "q8_0", "iq4_nl", "tq3_0"}) {
         string_to_spv("set_rows_" + t + "_i32",     "copy_to_quant.comp", {{"SET_ROWS", "1"}, {"DATA_A_" + to_uppercase(t), "1"}, {"B_TYPE", "uint"}, {"B_SIZE", "32"}, {"D_TYPE", "float"}, {"FLOAT_TYPE", "float"}});
         string_to_spv("set_rows_" + t + "_i32_rte", "copy_to_quant.comp", {{"SET_ROWS", "1"}, {"DATA_A_" + to_uppercase(t), "1"}, {"B_TYPE", "uint"}, {"B_SIZE", "32"}, {"D_TYPE", "float"}, {"FLOAT_TYPE", "float"}, {"RTE16", "1"}});
         string_to_spv("set_rows_" + t + "_i64",     "copy_to_quant.comp", {{"SET_ROWS", "1"}, {"DATA_A_" + to_uppercase(t), "1"}, {"B_TYPE", "uvec2"}, {"B_SIZE", "64"}, {"D_TYPE", "float"}, {"FLOAT_TYPE", "float"}});

--- a/src/llama-context.cpp
+++ b/src/llama-context.cpp
@@ -2953,11 +2953,6 @@ llama_context * llama_init_from_model(
         }
     }
 
-    // TQ3_0 K cache has no flash attention kernel support - force off
-    if (params.flash_attn_type != LLAMA_FLASH_ATTN_TYPE_DISABLED && params.type_k == GGML_TYPE_TQ3_0) {
-        LLAMA_LOG_WARN("%s: flash_attn is not supported with TQ3_0 K cache - forcing off\n", __func__);
-        params.flash_attn_type = LLAMA_FLASH_ATTN_TYPE_DISABLED;
-    }
 
     if (params.flash_attn_type == LLAMA_FLASH_ATTN_TYPE_AUTO && ggml_is_quantized(params.type_v)) {
         const uint32_t blck_size = ggml_blck_size(params.type_v);


### PR DESCRIPTION
Add hardware-accelerated TQ3_0 support for Vulkan and SYCL backends, enabling TQ3_0 KV cache on Intel Arc GPU with 58% VRAM savings vs q8_0.

Vulkan backend:
- types.glsl: add block_tq3_0_packed16 struct and A_TYPE_PACKED16 macro
- dequant_funcs.glsl: add dequantize/dequantize4/get_dm for TQ3_0 using 32-point Walsh-Hadamard Transform with Max-Lloyd centroids
- copy_to_quant.comp: TQ3_0 quantization path (F32 -> TQ3_0)
- dequant_tq3_0.comp: standalone dequantize shader (TQ3_0 -> F32)
- flash_attn_base.glsl: TQ3_0 dequantize4 for flash attention K/V path
- vulkan-shaders-gen.cpp: compile TQ3_0 shaders (cpy, dequant, mul_mat_vec, get_rows, flash_attn scalar path)
- ggml-vulkan.cpp: pipeline creation for cpy/dequant/mul_mat_vec/flash_attn, supports_op entries for CPY/DUP/CONT/MUL_MAT/FLASH_ATTN_EXT

SYCL backend:
- dequantize.hpp: TQ3_0 WHT dequantize kernel
- dmmv.cpp: dot-matrix-vector kernel for TQ3_0 x F32
- convert.cpp: F32 -> TQ3_0 and TQ3_0 -> F32 copy kernels
- ggml-sycl.cpp: register TQ3_0 pipelines

Shared:
- ggml-common.h: add QR_TQ3_0 = 1 macro
- llama-context.cpp: enable flash_attn for TQ3_0 KV cache (was force-disabled)

Tested on Intel Arc Pro B60 (24GB) with Qwen3.6-35B-A3B-IQ4_XS:
  ctx=32768, K+V q8_0: 340 MiB
  ctx=32768, K+V tq3_0: 140 MiB  (58.8% reduction, correct outputs verified)

TQ3_0 uses flash attention (FLASH_ATTN_EXT) since the K cache is accessed non-contiguously. Requires --cache-type-v tq3_0 alongside --cache-type-k tq3_0.

## Overview

<!-- Describe what this PR does and why. Be concise but complete -->

## Additional information

<!-- You can provide more details and link related discussions here. Delete this section if not applicable -->

# Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: <!-- mention: YES / NO - if yes, describe how AI was used -->

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
